### PR TITLE
Add support for CircleCI

### DIFF
--- a/metadata/metadata.go
+++ b/metadata/metadata.go
@@ -23,7 +23,7 @@ type Metadata interface {
 type AbstractMetadata struct {
 	Branch            string    `yaml:":branch"`
 	BuildURL          string    `yaml:":build_url"`
-	Check             string    `yaml:":check"`
+	Check             string    `yaml:":check" env:"BUILDPULSE_CHECK_NAME"`
 	CIProvider        string    `yaml:":ci_provider"`
 	Commit            string    `yaml:":commit"`
 	RepoNameWithOwner string    `yaml:":repo_name_with_owner"`
@@ -82,10 +82,8 @@ func newCircleMetadata(envs map[string]string, now func() time.Time) (Metadata, 
 	m.RepoNameWithOwner = fmt.Sprintf("%s/%s", m.CircleProjectUsername, m.CircleProjectReponame)
 	m.Timestamp = now()
 
-	m.Check = "circleci"
-	check := envs["BUILDPULSE_CHECK_NAME"]
-	if check != "" {
-		m.Check = check
+	if m.Check == "" {
+		m.Check = "circleci"
 	}
 
 	return m, nil
@@ -133,10 +131,8 @@ func newGithubMetadata(envs map[string]string, now func() time.Time) (Metadata, 
 	}
 	m.Branch = branch
 
-	m.Check = "github-actions"
-	check := envs["BUILDPULSE_CHECK_NAME"]
-	if check != "" {
-		m.Check = check
+	if m.Check == "" {
+		m.Check = "github-actions"
 	}
 
 	return m, nil
@@ -199,10 +195,8 @@ func newSemaphoreMetadata(envs map[string]string, now func() time.Time) (Metadat
 	m.RepoNameWithOwner = m.SemaphoreGitRepoSlug
 	m.Timestamp = now()
 
-	m.Check = "semaphore"
-	check := envs["BUILDPULSE_CHECK_NAME"]
-	if check != "" {
-		m.Check = check
+	if m.Check == "" {
+		m.Check = "semaphore"
 	}
 
 	return m, nil
@@ -262,10 +256,8 @@ func newTravisMetadata(envs map[string]string, now func() time.Time) (Metadata, 
 		m.TravisPullRequestNumber = uint(prNum)
 	}
 
-	m.Check = "travis-ci"
-	check := envs["BUILDPULSE_CHECK_NAME"]
-	if check != "" {
-		m.Check = check
+	if m.Check == "" {
+		m.Check = "travis-ci"
 	}
 
 	return m, nil

--- a/metadata/testdata/circle.yml
+++ b/metadata/testdata/circle.yml
@@ -1,0 +1,12 @@
+:branch: some-branch
+:build_url: https://circleci.com/gh/some-owner/some-repo/8675309
+:check: circleci
+:ci_provider: circleci
+:commit: 1f192ff735f887dd7a25229b2ece0422d17931f5
+:repo_name_with_owner: some-owner/some-repo
+:timestamp: 2020-07-11T01:02:03Z
+:circle_build_num: 1
+:circle_job: some-job
+:circle_repository_url: git@github.com:some-owner/some-repo.git
+:circle_username: some-committer
+:circle_workflow_id: 00000000-0000-0000-0000-000000000000


### PR DESCRIPTION
In addition to the existing support for GitHub Actions, Semaphore, and Travis CI, this pull request adds support for sending test results to BuildPulse from CircleCI.