### PR TITLE
Add support for Buildkite

### DIFF
--- a/metadata/testdata/buildkite.yml
+++ b/metadata/testdata/buildkite.yml
@@ -1,0 +1,16 @@
+:branch: some-branch
+:build_url: https://buildkite.com/some-org/some-project/builds/8675309
+:check: buildkite
+:ci_provider: buildkite
+:commit: 1f192ff735f887dd7a25229b2ece0422d17931f5
+:repo_name_with_owner: some-owner/some-repo
+:timestamp: 2020-07-11T01:02:03Z
+:buildkite_build_id: 00000000-0000-0000-0000-000000000000
+:buildkite_build_number: 42
+:buildkite_job_id: 11111111-1111-1111-1111-111111111111
+:buildkite_label: ':test_tube: Run tests'
+:buildkite_organization_slug: some-org
+:buildkite_pipeline_id: 22222222-2222-2222-2222-222222222222
+:buildkite_pipeline_slug: some-pipeline
+:buildkite_project_slug: some-org/some-project
+:buildkite_retry_count: 2


### PR DESCRIPTION
In addition to the existing support for CircleCI, GitHub Actions, Semaphore, and Travis CI, this pull request adds support for sending test results to BuildPulse from [Buildkite](https://buildkite.com).