### PR TITLE
Add support for webapp.io (formerly known as LayerCI)

### DIFF
--- a/internal/metadata/metadata_test.go
+++ b/internal/metadata/metadata_test.go
@@ -145,6 +145,21 @@ func TestNewMetadata(t *testing.T) {
 			},
 			fixture: "./testdata/travis.yml",
 		},
+		{
+			name: "webapp.io",
+			envs: map[string]string{
+				"GIT_BRANCH":        "some-branch",
+				"GIT_COMMIT":        "1f192ff735f887dd7a25229b2ece0422d17931f5",
+				"JOB_ID":            "42",
+				"ORGANIZATION_NAME": "some-org",
+				"REPOSITORY_NAME":   "some-repo",
+				"REPOSITORY_OWNER":  "some-owner",
+				"RETRY_INDEX":       "1",
+				"RUNNER_ID":         "main-layerfile",
+				"WEBAPPIO":          "true",
+			},
+			fixture: "./testdata/webapp.io.yml",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/metadata/providers_test.go
+++ b/internal/metadata/providers_test.go
@@ -262,6 +262,37 @@ func Test_travisMetadata_Init_extraFields(t *testing.T) {
 	}
 }
 
+func Test_webappioMetadata_Init_extraFields(t *testing.T) {
+	tests := []struct {
+		name          string
+		envs          map[string]string
+		expectedLines []string
+	}{
+		{
+			name: "with pull request",
+			envs: map[string]string{
+				"PULL_REQUEST_URL": "https://github.com/some-owner/some-repo/pull/1",
+			},
+			expectedLines: []string{
+				":pull_request_url: https://github.com/some-owner/some-repo/pull/1",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := webappioMetadata{}
+			err := meta.Init(tt.envs, logger.New())
+			assert.NoError(t, err)
+
+			yaml, err := yaml.Marshal(meta)
+			assert.NoError(t, err)
+			for _, line := range tt.expectedLines {
+				assert.Regexp(t, line, string(yaml))
+			}
+		})
+	}
+}
+
 func Test_nameWithOwnerFromGitURL(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/metadata/testdata/webapp.io.yml
+++ b/internal/metadata/testdata/webapp.io.yml
@@ -1,0 +1,19 @@
+:authored_at: 2020-07-09T04:05:06-05:00
+:author_email: some-author@example.com
+:author_name: Some Author
+:branch: some-branch
+:build_url: https://webapp.io/some-org/some-repo/42/main-layerfile-1
+:check: webapp.io
+:ci_provider: webapp.io
+:commit_message: Some message
+:commit_metadata_source: Static
+:commit: 1f192ff735f887dd7a25229b2ece0422d17931f5
+:committed_at: 2020-07-10T07:08:09+13:00
+:committer_email: some-committer@example.com
+:committer_name: Some Committer
+:repo_name_with_owner: some-owner/some-repo
+:reporter_os: linux
+:reporter_version: v1.2.3
+:timestamp: 2020-07-11T01:02:03Z
+:tree: 0da9df599c02da5e7f5058b7108dcd5e1929a0fe
+:retry_index: 1


### PR DESCRIPTION
Add support for submitting test results to BuildPulse from [webapp.io](https://webapp.io/).