### PR TITLE
chore: migrate CI to BuildPulse runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     name: Build
 
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
 
     steps:
       - name: Set up Go 1.x
@@ -53,7 +53,7 @@ jobs:
   govulncheck:
     name: Vulnerability check
 
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
 
     steps:
       - uses: actions/checkout@v2
@@ -73,7 +73,7 @@ jobs:
   smoke-test:
     name: Smoke test
 
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
 
     outputs:
       version: ${{ steps.get_version.outputs.version }}
@@ -149,7 +149,7 @@ jobs:
   verify-alpine:
     name: Verify binary (Alpine)
     needs: create-release
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
     steps:
       - name: Download binary from release
         run: gh release download ${{ needs.create-release.outputs.tag }} --repo ${{ github.repository }} --pattern 'test-reporter-linux-amd64' --dir dist
@@ -175,7 +175,7 @@ jobs:
   verify-ubuntu:
     name: Verify binary (Ubuntu)
     needs: create-release
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
     steps:
       - name: Download binary from release
         run: gh release download ${{ needs.create-release.outputs.tag }} --repo ${{ github.repository }} --pattern 'test-reporter-linux-amd64' --dir dist

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,7 +11,7 @@ jobs:
   linux-demo:
     name: Linux Demo
 
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
 
     steps:
       - name: Check out code

--- a/.github/workflows/release-asset-publication.yml
+++ b/.github/workflows/release-asset-publication.yml
@@ -9,7 +9,7 @@ jobs:
   publish-to-cloudflare:
     name: Publish to Cloudflare
 
-    runs-on: ubuntu-latest
+    runs-on: bp-ubuntu-latest-x64-2x
 
     steps:
       - name: Check out code


### PR DESCRIPTION
## Summary
- Migrate all GitHub Actions workflows from public GitHub-hosted runners to BuildPulse runners
- Runner: `bp-ubuntu-latest-x64-2x` (2 vCPU, 8 GB RAM, 75 GB SSD)
- No functional changes — same Ubuntu environment, faster execution

## What changed
All `runs-on: ubuntu-latest` (and `ubuntu-22.04`/`ubuntu-24.04`) replaced with `runs-on: bp-ubuntu-latest-x64-2x`

## Prerequisites
- BuildPulse GitHub App must be installed on this org
- Runner tenant must be activated in BuildPulse
- `bp-ubuntu-latest-x64-2x` runner config must be added